### PR TITLE
Alpaca annotator errors fixed

### DIFF
--- a/scripts/alpaca_eval_vllm_llama3_70b_fn/alpaca_eval_fn.txt
+++ b/scripts/alpaca_eval_vllm_llama3_70b_fn/alpaca_eval_fn.txt
@@ -18,11 +18,12 @@ Here are the outputs of the models:
         "answer": """{output_2}"""
     }
 ]
-Now please rank the models by the quality of their answers, so that the model with rank 1 has the best output. Then return a list of the model names and ranks, i.e., produce the following output:
+Now please rank the models by the quality of their answers, so that the model with rank 1 has the best output and the model with rank 2 has the worse output. Do not use any other rank values. Then return a list of the model names and ranks, i.e., produce the following output:
 [
-    {'model': <model-name>, 'rank': <model-rank>},
-    {'model': <model-name>, 'rank': <model-rank>}
+    {'model': <model-name>, 'rank': <1 or 2>},
+    {'model': <model-name>, 'rank': <1 or 2>}
 ]
+
 Your response must be a valid Python dictionary and should contain nothing else because we will directly execute it in Python. Please provide the ranking that the majority of humans would give.
 <|im_end|>
 <|im_start|>assistant

--- a/scripts/alpaca_eval_vllm_llama3_70b_fn/configs.yaml
+++ b/scripts/alpaca_eval_vllm_llama3_70b_fn/configs.yaml
@@ -6,7 +6,7 @@ alpaca_eval_vllm_llama3_70b_fn:
     model_kwargs:
       tokenizer_mode: "auto"
       trust_remote_code: True
-      max_model_len: 1000
+      max_model_len: 2500
       tp: 2
     max_new_tokens: 100
     temperature: 0.0


### PR DESCRIPTION
Fixes the alpaca_eval_fn.txt prompt used for the ranking_parser by adding explicit instructions that rank values must be either 1 or 2, where 1 indicates the preferred output. This resolves the assert error caused by invalid rank values (e.g., rank=0) encountered during evaluation. The updated prompt ensures compatibility with the ranking_parser logic and enables proper annotation of model outputs.

Additionally, this updates config.yaml to set max_model_len: 2500 (increased from 1000). This prevents input prompts longer than 1000 tokens from being silently skipped during annotation.